### PR TITLE
🐛 Put the id back in event default constructor for reflexion (#112)

### DIFF
--- a/cli/src/main/jte/domain/event/DomainEvent.jte
+++ b/cli/src/main/jte/domain/event/DomainEvent.jte
@@ -8,12 +8,11 @@ import ${domainPackage}.domain.entity.${domain}
 import me.elgregos.reakteves.domain.event.Event
 import me.elgregos.reakteves.libs.genericObjectMapper
 import me.elgregos.reakteves.libs.nowUTC
-import me.elgregos.reakteves.libs.uuidV7
 import java.time.LocalDateTime
 import java.util.*
 
 sealed class ${domain}Event(
-    id: UUID = uuidV7(),
+    id: UUID,
     version: Int,
     createdAt: LocalDateTime,
     createdBy: UUID,
@@ -25,18 +24,20 @@ sealed class ${domain}Event(
 ) {
 
     data class ${domain}Created(
+        override val id: UUID,
         override val version: Int = 1,
         override val createdAt: LocalDateTime = nowUTC(),
         override val createdBy: UUID,
         val ${domainPrefix}Id: UUID,
         override val event: JsonNode
     ) : ${domain}Event(
-        version = version,
-        createdAt = createdAt,
-        createdBy = createdBy,
-        aggregateId = ${domainPrefix}Id,
-        eventType = ${domain}Created::class.simpleName!!,
-        event = event
+        id,
+        version,
+        createdAt,
+        createdBy,
+        ${domainPrefix}Id,
+        ${domain}Created::class.simpleName!!,
+        event
     ) {
         constructor(${domainPrefix}: ${domain}) : this(
             ${domainPrefix}Id = ${domainPrefix}.id,

--- a/cli/src/test/kotlin/me/elgregos/reakteves/cli/generator/domain/event/DomainEventGeneratorTest.kt
+++ b/cli/src/test/kotlin/me/elgregos/reakteves/cli/generator/domain/event/DomainEventGeneratorTest.kt
@@ -22,12 +22,11 @@ internal class DomainEventGeneratorTest: GeneratorTest() {
             import me.elgregos.reakteves.domain.event.Event
             import me.elgregos.reakteves.libs.genericObjectMapper
             import me.elgregos.reakteves.libs.nowUTC
-            import me.elgregos.reakteves.libs.uuidV7
             import java.time.LocalDateTime
             import java.util.*
 
             sealed class GameEvent(
-                id: UUID = uuidV7(),
+                id: UUID,
                 version: Int,
                 createdAt: LocalDateTime,
                 createdBy: UUID,
@@ -39,18 +38,20 @@ internal class DomainEventGeneratorTest: GeneratorTest() {
             ) {
 
                 data class GameCreated(
+                    override val id: UUID,
                     override val version: Int = 1,
                     override val createdAt: LocalDateTime = nowUTC(),
                     override val createdBy: UUID,
                     val gameId: UUID,
                     override val event: JsonNode
                 ) : GameEvent(
-                    version = version,
-                    createdAt = createdAt,
-                    createdBy = createdBy,
-                    aggregateId = gameId,
-                    eventType = GameCreated::class.simpleName!!,
-                    event = event
+                    id,
+                    version,
+                    createdAt,
+                    createdBy,
+                    gameId,
+                    GameCreated::class.simpleName!!,
+                    event
                 ) {
                     constructor(game: Game) : this(
                         gameId = game.id,


### PR DESCRIPTION
Closes #112